### PR TITLE
Add support for automatic master account matching

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,9 @@
 services:
   jericho:
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile
-    image: ghcr.io/violetrimberg/cephalon-jericho:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    # image: ghcr.io/violetrimberg/cephalon-jericho:latest
     restart: unless-stopped
     volumes:
       - ./state.json:/app/state.json

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = . src

--- a/src/jericho.py
+++ b/src/jericho.py
@@ -112,6 +112,7 @@ async def hello(ctx):
         MESSAGE_PROVIDER("HELLO", user=ctx.user.display_name)
     )
 
+
 @tree.command(
     name="tough_love",
     description="Ask Jericho for honest advice",
@@ -121,6 +122,7 @@ async def tough_love(ctx):
     await ctx.response.send_message(
         MESSAGE_PROVIDER("TOUGH_LOVE", user=ctx.user.display_name)
     )
+
 
 @tree.command(
     name="feeling_lost",
@@ -132,6 +134,7 @@ async def feeling_lost(ctx):
         MESSAGE_PROVIDER("LOST", user=ctx.user.display_name)
     )
 
+
 @tree.command(
     name="trivia",
     description="Ask Jericho for a fact",
@@ -141,6 +144,7 @@ async def trivia(ctx):
     await ctx.response.send_message(
         MESSAGE_PROVIDER("TRIVIA", user=ctx.user.display_name)
     )
+
 
 @tree.command(
     name="rate_outfit",
@@ -440,7 +444,9 @@ class JudgeJerichoView(View):
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
         global STATE
-        await interaction.response.send_message(MESSAGE_PROVIDER("AFFIRM_YES", user=interaction.user.name))
+        await interaction.response.send_message(
+            MESSAGE_PROVIDER("AFFIRM_YES", user=interaction.user.name)
+        )
 
     @discord.ui.button(label="No", style=ButtonStyle.secondary)
     async def take_him_to_the_farm(

--- a/src/riven_grader.py
+++ b/src/riven_grader.py
@@ -1,10 +1,3 @@
-from dataclasses import dataclass
-from jinja2 import Environment
-import csv
-import httpx
-from typing import List
-
-
 class RivenGrader:
     def grade_riven(
         self,

--- a/src/riven_provider.py
+++ b/src/riven_provider.py
@@ -1,8 +1,5 @@
-from dataclasses import dataclass
-from jinja2 import Environment
 import csv
 import httpx
-from typing import List
 
 
 class RivenProvider:

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+from .http import HardenedHttpClient, DEFAULT_SUCCESS_CODES, WARFRAME_API_SUCCESS_CODES

--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -1,0 +1,60 @@
+import httpx
+import asyncio
+import logging
+
+DEFAULT_SUCCESS_CODES = [200, 201, 202, 203, 204, 205, 206, 207, 208]
+WARFRAME_API_SUCCESS_CODES = [200, 201, 202, 203, 204, 205, 206, 207, 208, 409]
+
+
+class HardenedHttpClient:
+    """
+    A hardened HTTP client that uses the httpx library, with retry policies and timeouts.
+    """
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        success_codes: list[int] = DEFAULT_SUCCESS_CODES,
+        retries: int = 5,
+        wait_time: int = 1,
+    ):
+        self.client = client
+        self.success_codes = success_codes
+        self.retries = retries
+        self.wait_time = wait_time
+
+    async def get(self, url: str, **kwargs) -> httpx.Response:
+        retries = 0
+        while retries < self.retries:
+            try:
+                result = await self.client.get(url, **kwargs)
+            except Exception as e:
+                logging.debug(f"An error occurred while trying to GET `{url}`: {e}")
+                await asyncio.sleep(self.wait_time)
+                retries += 1
+                continue
+
+            if result.status_code in self.success_codes:
+                return result
+            else:
+                await asyncio.sleep(self.wait_time)
+                retries += 1
+        return result
+
+    async def post(self, url: str, **kwargs) -> httpx.Response:
+        retries = 0
+        while retries < self.retries:
+            try:
+                result = await self.client.post(url, **kwargs)
+            except Exception as e:
+                logging.debug(f"An error occurred while trying to POST `{url}`: {e}")
+                await asyncio.sleep(self.wait_time)
+                retries += 1
+                continue
+
+            if result.status_code in self.success_codes:
+                return result
+            else:
+                await asyncio.sleep(self.wait_time)
+                retries += 1
+        return result

--- a/src/warframe.py
+++ b/src/warframe.py
@@ -6,7 +6,7 @@ import logging
 from enum import Enum
 import asyncio
 import re
-from .utils.http import HardenedHttpClient, WARFRAME_API_SUCCESS_CODES
+from utils.http import HardenedHttpClient, WARFRAME_API_SUCCESS_CODES
 
 
 class Platform(Enum):
@@ -58,14 +58,14 @@ class Profile:
 
     Attributes:
         username (str): The player's username.
-        clan (str): The player's clan.
+        clan (Optional[str]): The player's clan.
         mr (int): The player's mastery rank.
         multi_platform (bool): Whether the player is registered on multiple platforms.
         platform_names (dict[Platform, str]): A dictionary of the player's platform
     """
 
     username: str  # The player's primary username
-    clan: str
+    clan: Optional[str]
     mr: int
     multi_platform: bool
     platform_names: dict[Platform, str]
@@ -111,7 +111,10 @@ class WarframeAPI:
             converted_platform_names = {source_platform: username}
 
         mr = profile_data["PlayerLevel"]
-        clan = profile_data["GuildName"].split("#")[0]
+        if "GuildName" in profile_data:
+            clan = profile_data["GuildName"].split("#")[0]
+        else:
+            clan = None
 
         return Profile(
             username=username,

--- a/src/warframe.py
+++ b/src/warframe.py
@@ -6,6 +6,8 @@ import logging
 from enum import Enum
 import asyncio
 import re
+from .utils.http import HardenedHttpClient, WARFRAME_API_SUCCESS_CODES
+
 
 class Platform(Enum):
     PC = "PC"
@@ -61,8 +63,9 @@ class Profile:
         multi_platform (bool): Whether the player is registered on multiple platforms.
         platform_names (dict[Platform, str]): A dictionary of the player's platform
     """
-    username: str # The player's primary username
-    clan: str 
+
+    username: str  # The player's primary username
+    clan: str
     mr: int
     multi_platform: bool
     platform_names: dict[Platform, str]
@@ -74,17 +77,30 @@ class WarframeAPI:
     """
 
     def __init__(self, timeout: int = 10_000):
-        self.client = httpx.AsyncClient(timeout=timeout)  # Initialize the HTTP client
+        self.client = HardenedHttpClient(
+            httpx.AsyncClient(timeout=timeout), success_codes=WARFRAME_API_SUCCESS_CODES
+        )  # Initialize the HTTP client
 
-    def _parse_profile(self, data: dict, source_platform:Platform) -> Profile:
+    def _parse_profile(self, data: dict, source_platform: Platform) -> Profile:
         profile_data = data["Results"][0]
 
-        #Remove the Platform PUA character
+        is_tutorial_account = "PlayerLevel" not in profile_data
+        if is_tutorial_account:
+            logging.warning(
+                f"Account `{profile_data['DisplayName']}` on platform `{source_platform}` is a tutorial account. Returning None!"
+            )
+            return None
+
         multi_platform = "PlatformNames" in profile_data
         if multi_platform:
+            # Remove the Platform PUA character
             username = profile_data["DisplayName"][:-1].strip()
 
-            all_platform_names = set([profile_data["DisplayName"]] + profile_data["PlatformNames"] if  multi_platform else [])
+            all_platform_names = set(
+                [profile_data["DisplayName"]] + profile_data["PlatformNames"]
+                if multi_platform
+                else []
+            )
             converted_platform_names = {}
             for platform_name in all_platform_names:
                 platform = Platform.from_PUA(platform_name[-1])
@@ -97,7 +113,13 @@ class WarframeAPI:
         mr = profile_data["PlayerLevel"]
         clan = profile_data["GuildName"].split("#")[0]
 
-        return Profile(username=username, mr=mr, clan=clan,multi_platform=multi_platform, platform_names=converted_platform_names)
+        return Profile(
+            username=username,
+            mr=mr,
+            clan=clan,
+            multi_platform=multi_platform,
+            platform_names=converted_platform_names,
+        )
 
     def clean_username(self, username: str) -> str:
         """
@@ -113,34 +135,44 @@ class WarframeAPI:
         return f"{platform.url()}dynamic/getProfileViewingData.php?n={urllib.parse.quote_plus(clean_username)}"
 
     async def get_profile(self, username: str, platform: Platform) -> Optional[Profile]:
+        logging.debug(f"Getting profile for `{username}` on platform `{platform}` ...")
         url = self.build_url(username, platform)
         response = await self.client.get(url)
 
-        #Check if we got a 409 response, this can happen if the user has linked their account to a different platform
+        # Check if we got a 409 response, this can happen if the user has linked their account to a different platform
         if response.status_code == 409:
             try:
                 message = response.text
-                match = re.search(r"Retry with (\w+) account: ([a-f0-9]+),(\w+)", message)
+                match = re.search(
+                    r"Retry with (\w+) account: ([a-f0-9]+),(\w+)", message
+                )
                 if match:
                     platform = Platform(match.group(1))
                     master_username = match.group(3)
-                    #Retry with the new platform
-                    logging.info(f"Retrying profile `{username}` with platform: {platform} and username: {master_username}")
+                    # Retry with the new platform
+                    logging.info(
+                        f"Retrying profile `{username}` with platform: {platform} and username: {master_username}"
+                    )
                     return await self.get_profile(master_username, platform)
                 else:
-                    logging.info(f"Didn't find user `{username}` on platform {platform}")
+                    logging.info(
+                        f"Didn't find user `{username}` on platform {platform}"
+                    )
+                    return None
             except Exception as e:
-                logging.error(f"Failed to parse platform from message: {message} with error: {e}")
+                logging.error(
+                    f"Failed to parse platform from message: {message} with error: {e}"
+                )
         try:
             response.raise_for_status()
             return self._parse_profile(response.json(), source_platform=platform)
         except httpx.HTTPError as e:
-            logging.error(f"Failed to get profile `{username}`: {e}")
+            logging.error(
+                f"Failed to get profile `{username}` on platform `{platform}`: {e}"
+            )
         return None
 
-    async def get_profile_all_platforms(
-        self, username: str
-    ) -> Optional[Profile]:
+    async def get_profile_all_platforms(self, username: str) -> Optional[Profile]:
         tasks = []
         for platform in Platform:
             if platform == Platform.UNKNOWN:

--- a/test/warframe_test.py
+++ b/test/warframe_test.py
@@ -79,6 +79,19 @@ async def test_doesnt_retrieve_non_existing_profile():
     assert warframe_profile is None
 
 
+@pytest.mark.parametrize(
+    "username",
+    [
+        ("Dazzle"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_can_get_profile_without_clan(username: str):
+    api = WarframeAPI()
+    warframe_profile = await api.get_profile_all_platforms(username)
+    assert warframe_profile is not None
+
+
 @pytest.mark.asyncio
 async def test_can_make_bulk_requests():
     api = WarframeAPI()

--- a/test/warframe_test.py
+++ b/test/warframe_test.py
@@ -12,6 +12,8 @@ def test_is_constructable():
     [
         ("LLukas22", Platform.PC),
         ("ScaledValkyrie", Platform.PS4),
+        ("GrantTheWish", Platform.PS4), # This is a multi-platform user which has a different username on PC
+        ("LLukas44", Platform.SWITCH),
     ],
 )
 @pytest.mark.asyncio
@@ -19,25 +21,25 @@ async def test_can_get_profile(username: str, platform: Platform):
     api = WarframeAPI()
     warframe_profile = await api.get_profile(username, platform)
     assert warframe_profile is not None
-    assert warframe_profile.username == username
+    assert warframe_profile.platform_names[platform] == username
 
 
 @pytest.mark.parametrize(
-    "username, expected_platform",
+    "username, platform",
     [
         ("LLukas22", Platform.PC),
         ("ScaledValkyrie", Platform.PS4),
+        ("LLukas44", Platform.SWITCH),
     ],
 )
 @pytest.mark.asyncio
 async def test_can_get_profile_from_all_platforms(
-    username: str, expected_platform: Platform
+    username: str, platform: Platform
 ):
     api = WarframeAPI()
-    warframe_profile, platform = await api.get_profile_all_platforms(username)
+    warframe_profile = await api.get_profile_all_platforms(username)
     assert warframe_profile is not None
-    assert platform == expected_platform
-    assert warframe_profile.username == username
+    assert warframe_profile.platform_names[platform] == username
 
 
 @pytest.mark.asyncio

--- a/test/warframe_test.py
+++ b/test/warframe_test.py
@@ -1,5 +1,6 @@
 import pytest
 from src.warframe import WarframeAPI, Platform
+import asyncio
 
 
 def test_is_constructable():
@@ -12,8 +13,20 @@ def test_is_constructable():
     [
         ("LLukas22", Platform.PC),
         ("ScaledValkyrie", Platform.PS4),
-        ("GrantTheWish", Platform.PS4), # This is a multi-platform user which has a different username on PC
+        (
+            "GrantTheWish",
+            Platform.PS4,
+        ),  # This is a multi-platform user which has a different username on PC
+        (
+            "Victor_Z_1992",
+            Platform.PS4,
+        ),  # This is a multi-platform user which has the same username on PC
         ("LLukas44", Platform.SWITCH),
+        ("scifilord2003", Platform.XBOX),
+        (
+            "LivewareProblem",
+            Platform.PC,
+        ),  # This account has an account with a similar name on the Switch
     ],
 )
 @pytest.mark.asyncio
@@ -26,25 +39,52 @@ async def test_can_get_profile(username: str, platform: Platform):
 
 @pytest.mark.parametrize(
     "username, platform",
+    [("LivewareProblem", Platform.SWITCH), ("sayed3210", Platform.PC)],
+)
+@pytest.mark.asyncio
+async def test_doesnt_retrieve_pre_merge_slave_accounts(
+    username: str, platform: Platform
+):
+    api = WarframeAPI()
+    warframe_profile = await api.get_profile(username, platform)
+    assert warframe_profile is None
+
+
+@pytest.mark.parametrize(
+    "username, platform, is_multi_platform",
     [
-        ("LLukas22", Platform.PC),
-        ("ScaledValkyrie", Platform.PS4),
-        ("LLukas44", Platform.SWITCH),
-        ("LivewareProblem", Platform.PC)
+        ("LLukas22", Platform.PC, True),
+        ("LivewareProblem", Platform.PC, False),
+        ("Victor_Z_1992", Platform.PS4, True),
+        ("ScaledValkyrie", Platform.PS4, False),
+        ("scifilord2003", Platform.XBOX, False),
+        ("LLukas44", Platform.SWITCH, True),
     ],
 )
 @pytest.mark.asyncio
 async def test_can_get_profile_from_all_platforms(
-    username: str, platform: Platform
+    username: str, platform: Platform, is_multi_platform: bool
 ):
     api = WarframeAPI()
     warframe_profile = await api.get_profile_all_platforms(username)
     assert warframe_profile is not None
+    assert warframe_profile.multi_platform == is_multi_platform
     assert warframe_profile.platform_names[platform] == username
 
 
 @pytest.mark.asyncio
 async def test_doesnt_retrieve_non_existing_profile():
     api = WarframeAPI()
-    warframe_profile = await api.get_profile("DefinetlyNotLLukas22", Platform.PC)
+    warframe_profile = await api.get_profile_all_platforms("DefinetlyNotLLukas22")
     assert warframe_profile is None
+
+
+@pytest.mark.asyncio
+async def test_can_make_bulk_requests():
+    api = WarframeAPI()
+    usernames = ["LLukas22", "LivewareProblem", "Victor_Z_1992"] * 5
+    tasks = [api.get_profile_all_platforms(username) for username in usernames]
+    profiles = await asyncio.gather(*tasks)
+
+    for profile in profiles:
+        assert profile is not None


### PR DESCRIPTION
Makes the Warframe API client a lot more robust and allows it to automatically handle linked accounts.

Also extends `/profile` to fetch all platform accounts of a user.

![image](https://github.com/user-attachments/assets/0f6c7a39-4d62-4d67-92e5-26e0111fdc82)
